### PR TITLE
fix escapeValueContainingDelimiter function

### DIFF
--- a/src/utils/json-to-csv.js
+++ b/src/utils/json-to-csv.js
@@ -1,6 +1,6 @@
 function escapeValueContainingDelimiter(data, delimiter) {
-  if (data && typeof data === 'string' && (data.indexOf(delimiter) > -1 || data.indexOf("\n") > -1)) {
-    return `"${data.replace(/\"/g, "\"\"").replace(/\n/g, " ")}"`;
+  if (data && typeof data === 'string' && (data.indexOf(delimiter) > -1 || data.indexOf('\n') > -1)) {
+    return `"${data.replace(/\"/g, '""').replace(/\n/g, ' ')}"`;
   }
 
   return data;

--- a/src/utils/json-to-csv.js
+++ b/src/utils/json-to-csv.js
@@ -1,6 +1,6 @@
 function escapeValueContainingDelimiter(data, delimiter) {
   if (data && typeof data === 'string' && (data.indexOf(delimiter) > -1 || data.indexOf('\n') > -1)) {
-    return `"${data.replace(/\"/g, '""').replace(/\n/g, ' ')}"`;
+    return `"${data.replace(/"/g, '""').replace(/\n/g, ' ')}"`;
   }
 
   return data;

--- a/src/utils/json-to-csv.js
+++ b/src/utils/json-to-csv.js
@@ -1,6 +1,6 @@
 function escapeValueContainingDelimiter(data, delimiter) {
-  if (data && typeof data === 'string' && data.indexOf(delimiter) > -1) {
-    return `"${data}"`;
+  if (data && typeof data === 'string' && (data.indexOf(delimiter) > -1 || data.indexOf("\n") > -1)) {
+    return `"${data.replace(/\"/g, "\"\"").replace(/\n/g, " ")}"`;
   }
 
   return data;

--- a/test/unit/table.spec.js
+++ b/test/unit/table.spec.js
@@ -64,6 +64,16 @@ describe('Table', () => {
       expect(new Table(jsonData, 'TableName').getScript()).to.eql('LOAD\n*\nINLINE "\n""Head,er1"",Header2\n""a,1"",1\na2,b2\na3,b3\n"\n(txt);');
     });
 
+    it('should escape JSON data that contains separator character and double quotes', () => {
+      const jsonData = [{ 'Head,er1': '"a,1"', Header2: 1 }, { 'Head,er1': 'a,"2"', Header2: 'b2' }, { 'Head,er1': 'a3', Header2: 'b3' }];
+      expect(new Table(jsonData, 'TableName').getScript()).to.eql('LOAD\n*\nINLINE "\n""Head,er1"",Header2\n""""""a,1"""""",1\n""a,""""2"""""",b2\na3,b3\n"\n(txt);');
+    });
+
+    it('should replace new lines with spaces and escape JSON data that contains new lines', () => {
+      const jsonData = [{ 'Head,er1': 'a\n1', Header2: 1 }, { 'Head,er1': 'a2', Header2: 'b2' }, { 'Head,er1': 'a3', Header2: 'b3' }];
+      expect(new Table(jsonData, 'TableName').getScript()).to.eql('LOAD\n*\nINLINE "\n""Head,er1"",Header2\n""a 1"",1\na2,b2\na3,b3\n"\n(txt);');
+    });
+
     it('should be possible to add a path and a file connection should be created', () => {
       const filePath = 'C:\\data\\data.txt';
       const table = new Table(filePath, 'TableName');


### PR DESCRIPTION
Fixes #5 

According to RFC 4180, in such an instance the double quotation marks should also be escaped by preceding it with another double quotation mark.
Also, according to RFC 4180 any fields containing line breaks should also be enclosed in double quotations.

These changes have been implemented to the escapeValueContainingDelimiter function. In addition, the escapeValueContainingDelimiter function now also removes all line breaks, as simply enclosing fields which contained line breaks in double quotations did not fix the issue.

### Status
```
[ ] Under development
[x] Waiting for code review
[ ] Waiting for merge
```