### PR TITLE
Properly format SET statements

### DIFF
--- a/src/set-statement.js
+++ b/src/set-statement.js
@@ -5,7 +5,7 @@ class SetStatement {
 
   getScript() {
     return Object.keys(this.defaultSetStatements)
-      .map(key => `SET ${key}='${this.defaultSetStatements[key]}';`)
+      .map(key => `SET ${key}='${Array.isArray(this.defaultSetStatements[key]) ? this.defaultSetStatements[key].join(';') : this.defaultSetStatements[key]}';`)
       .join('\n');
   }
 

--- a/test/unit/halyard.spec.js
+++ b/test/unit/halyard.spec.js
@@ -110,6 +110,11 @@ describe('Halyard', () => {
       expect(halyard.getScript()).to.eql('SET test=\'1\';\nSET test2=\'2\';');
     });
 
+    it('should join set statment array values with a semicolon', () => {
+      halyard.setDefaultSetStatements({ test: [1,2,3], test2: 2 });
+      expect(halyard.getScript()).to.eql('SET test=\'1;2;3\';\nSET test2=\'2\';');
+    });
+
     it('should not replace previously entered default statements', () => {
       halyard.setDefaultSetStatements({ test: 'first' });
       halyard.setDefaultSetStatements({ test: 'second', test2: 'second' }, true);


### PR DESCRIPTION
Fixes #7 

The problem is that arrays were being converted to strings when concatenated with the rest of the SET string, but they need to be joined first with a semicolon separator to be properly formatted. 

### Status
```
[ ] Under development
[x] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains documentation
[x] Contains test
```
