### PR TITLE
Updates the Halyard mixin to support enigma 2+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "halyard.js",
   "version": "1.2.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",
@@ -13,7 +14,11 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "5.1.2",
@@ -26,6 +31,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -46,12 +54,72 @@
       "resolved": "https://registry.npmjs.org/after-work.js/-/after-work.js-3.1.2.tgz",
       "integrity": "sha512-Vj4IiE5Po0OvySMNx5cInb1of+XeJ1HzJ4BAujh47IurSkPXaFojmMxsU6l2qqrPNT5SFBkgwGkP1lDV8mnh3Q==",
       "dev": true,
+      "requires": {
+        "babel-cli": "6.26.0",
+        "babel-core": "6.26.0",
+        "babel-preset-env": "1.6.0",
+        "babel-register": "6.26.0",
+        "bluebird": "3.5.1",
+        "browser-sync": "2.18.13",
+        "chai": "4.1.1",
+        "chai-as-promised": "7.1.1",
+        "chai-subset": "1.6.0",
+        "commander": "2.11.0",
+        "coveralls": "3.0.0",
+        "extend": "3.0.1",
+        "globby": "6.1.0",
+        "handlebars": "4.0.10",
+        "highlight.js": "9.12.0",
+        "jimp": "0.2.28",
+        "mkdirp": "0.5.1",
+        "mocha": "4.0.1",
+        "moment": "2.19.1",
+        "nyc": "11.2.1",
+        "object.assign": "4.0.4",
+        "request": "2.83.0",
+        "sinon": "4.0.1",
+        "sinon-chai": "2.14.0",
+        "systemjs": "0.20.19",
+        "util": "0.10.3"
+      },
       "dependencies": {
         "babel-preset-env": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
           "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-async-to-generator": "6.24.1",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+            "babel-plugin-transform-es2015-object-super": "6.24.1",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "6.24.1",
+            "babel-plugin-transform-regenerator": "6.26.0",
+            "browserslist": "2.5.1",
+            "invariant": "2.2.2",
+            "semver": "5.4.1"
+          }
         }
       }
     },
@@ -59,7 +127,11 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -71,7 +143,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -101,19 +178,29 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -125,7 +212,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -161,7 +251,10 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -215,127 +308,265 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.11.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "babel-core": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
     },
     "babel-generator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-regex": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-loader": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "0.1.1",
+        "loader-utils": "0.2.17",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-istanbul": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "test-exclude": "4.1.1"
+      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
         }
       }
     },
@@ -361,163 +592,287 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
+      },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -531,43 +886,138 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.5.1",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      }
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
+      }
     },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
     },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
     },
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.18.0",
@@ -616,13 +1066,19 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
     },
     "big.js": {
       "version": "3.2.0",
@@ -664,19 +1120,31 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -688,37 +1156,87 @@
       "version": "2.18.13",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
       "integrity": "sha512-qhdrmgshVGwweogT/bdOKkZDxVxqiF4+9mibaDeAxvDBeoUtdgABk5x7YQ1KCcLRchAfv8AVtp9NuITl5CTNqg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browser-sync-client": "2.5.1",
+        "browser-sync-ui": "0.6.3",
+        "bs-recipes": "1.3.4",
+        "chokidar": "1.7.0",
+        "connect": "3.5.0",
+        "dev-ip": "1.0.1",
+        "easy-extender": "2.3.2",
+        "eazy-logger": "3.0.2",
+        "emitter-steward": "1.0.0",
+        "fs-extra": "3.0.1",
+        "http-proxy": "1.15.2",
+        "immutable": "3.8.1",
+        "localtunnel": "1.8.3",
+        "micromatch": "2.3.11",
+        "opn": "4.0.2",
+        "portscanner": "2.1.1",
+        "qs": "6.2.1",
+        "resp-modifier": "6.0.2",
+        "rx": "4.1.0",
+        "serve-index": "1.8.0",
+        "serve-static": "1.12.2",
+        "server-destroy": "1.0.1",
+        "socket.io": "1.6.0",
+        "socket.io-client": "1.6.0",
+        "ua-parser-js": "0.7.12",
+        "yargs": "6.4.0"
+      }
     },
     "browser-sync-client": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
       "integrity": "sha1-7BrWmknC4tS2RbGLHAbCmz2a+Os=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "etag": "1.8.1",
+        "fresh": "0.3.0"
+      }
     },
     "browser-sync-ui": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
       "integrity": "sha1-ZApTfBgGiTA9W+krxHa568RBwLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async-each-series": "0.1.1",
+        "connect-history-api-fallback": "1.4.0",
+        "immutable": "3.8.1",
+        "server-destroy": "1.0.1",
+        "stream-throttle": "0.1.3",
+        "weinre": "2.0.0-pre-I0Z7U9OV"
+      }
     },
     "browserify-aes": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
       "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pako": "0.2.9"
+      }
     },
     "browserslist": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
       "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000748",
+        "electron-to-chromium": "1.3.26"
+      }
     },
     "bs-recipes": {
       "version": "1.3.4",
@@ -730,7 +1248,12 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
     },
     "buffer-equal": {
       "version": "0.0.1",
@@ -754,7 +1277,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsite": {
       "version": "1.0.0",
@@ -790,25 +1316,43 @@
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "0.3.0"
+      }
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
       "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "2.0.2",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
+      }
     },
     "chai-as-promised": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2"
+      }
     },
     "chai-subset": {
       "version": "1.6.0",
@@ -820,7 +1364,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "check-error": {
       "version": "1.0.2",
@@ -832,7 +1383,17 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -844,7 +1405,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.2.0",
@@ -856,7 +1420,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
     },
     "clone": {
       "version": "1.0.2",
@@ -880,7 +1449,10 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.11.0",
@@ -922,19 +1494,33 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "connect": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
       "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "finalhandler": "0.5.0",
+        "parseurl": "1.3.2",
+        "utils-merge": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -954,7 +1540,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -997,6 +1586,13 @@
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
       "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.83.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -1010,37 +1606,61 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.0.tgz",
       "integrity": "sha512-R+0paw9UZQc7odHjIxElqyYotgyMlhcUMTfRxiv4I22grgvS5WOSSfCpyfAZUDhP/c9ShSRv+Hzfxs6fY4JA7g==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.1"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "crypto-browserify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
       "integrity": "sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-aes": "0.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.35"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1060,7 +1680,10 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1073,6 +1696,9 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
       "dev": true,
+      "requires": {
+        "type-detect": "3.0.0"
+      },
       "dependencies": {
         "type-detect": {
           "version": "3.0.0",
@@ -1092,19 +1718,40 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      },
       "dependencies": {
         "globby": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
         }
       }
     },
@@ -1130,7 +1777,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "dev-ip": {
       "version": "1.0.1",
@@ -1148,7 +1798,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "dom-walk": {
       "version": "0.1.1",
@@ -1167,6 +1821,9 @@
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "dev": true,
+      "requires": {
+        "lodash": "3.10.1"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -1180,14 +1837,20 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tfunk": "3.1.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1224,18 +1887,33 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
       "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "0.1.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.1",
+        "ws": "1.1.1"
+      },
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-types": "2.1.17",
+            "negotiator": "0.6.1"
+          }
         },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -1247,7 +1925,11 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
           "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
         }
       }
     },
@@ -1256,6 +1938,20 @@
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
       "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "1.1.1",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -1267,7 +1963,10 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -1279,7 +1978,11 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
           "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
         }
       }
     },
@@ -1288,12 +1991,23 @@
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
       "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
       "dev": true,
+      "requires": {
+        "after": "0.8.1",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.6",
+        "wtf-8": "1.0.0"
+      },
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -1308,6 +2022,11 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.2.0",
+        "tapable": "0.1.10"
+      },
       "dependencies": {
         "memory-fs": {
           "version": "0.2.0",
@@ -1318,40 +2037,63 @@
       }
     },
     "enigma.js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/enigma.js/-/enigma.js-1.3.1.tgz",
-      "integrity": "sha1-8cGBBhDj5S9vBFUPgCs8bXmzB4w=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/enigma.js/-/enigma.js-2.2.0.tgz",
+      "integrity": "sha512-FY67VY+TXJ/Pb8PMFLEYZ09532QeSOrsC7mYE9W9a5gyPfC+yW4iVc0OGMcnSfyhrS9odzquC3eyXgDjyeC7tQ==",
       "dev": true
     },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.35",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
       "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-promise": {
       "version": "3.3.1",
@@ -1363,19 +2105,36 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1393,13 +2152,56 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.5.1",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
@@ -1411,7 +2213,10 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
         }
       }
     },
@@ -1419,7 +2224,10 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-12.0.0.tgz",
       "integrity": "sha1-qygrdWol8D0ErCZMJNZzoIqAMnA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "8.0.0"
+      }
     },
     "eslint-config-airbnb-base": {
       "version": "8.0.0",
@@ -1431,19 +2239,46 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "object-assign": "4.1.1",
+        "resolve": "1.4.0"
+      }
     },
     "eslint-plugin-import": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-1.16.0.tgz",
       "integrity": "sha1-svoH68xTUE0PKkR3WC7Iv/GHG58=",
       "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.3.0",
+        "es6-map": "0.1.5",
+        "es6-set": "0.1.5",
+        "eslint-import-resolver-node": "0.2.3",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "lodash.endswith": "4.2.1",
+        "lodash.find": "4.6.0",
+        "lodash.findindex": "4.6.0",
+        "minimatch": "3.0.4",
+        "object-assign": "4.1.1",
+        "pkg-dir": "1.0.0",
+        "pkg-up": "1.0.0"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
           "integrity": "sha1-E+dWgrVVGEJCdvfBc3g0Vu+RPSY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         }
       }
     },
@@ -1451,7 +2286,11 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "4.0.0",
@@ -1463,13 +2302,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -1493,7 +2339,11 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -1523,25 +2373,42 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "express": {
       "version": "2.5.11",
       "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
       "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
       "dev": true,
+      "requires": {
+        "connect": "1.9.2",
+        "mime": "1.2.4",
+        "mkdirp": "0.3.0",
+        "qs": "0.4.2"
+      },
       "dependencies": {
         "connect": {
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
           "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "formidable": "1.0.17",
+            "mime": "1.2.4",
+            "qs": "0.4.2"
+          }
         },
         "mkdirp": {
           "version": "0.3.0",
@@ -1567,7 +2434,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -1591,13 +2461,21 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
     },
     "file-type": {
       "version": "3.9.0",
@@ -1615,19 +2493,36 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "finalhandler": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1641,25 +2536,43 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1671,7 +2584,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -1689,13 +2605,21 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
     },
     "formidable": {
       "version": "1.0.17",
@@ -1713,7 +2637,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.1",
+        "universalify": "0.1.1"
+      }
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -1726,776 +2655,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "dev": true,
-          "optional": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "optional": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "optional": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "optional": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "dev": true,
-          "optional": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
-          "optional": true
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-          "dev": true,
-          "optional": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "dev": true,
-          "optional": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-          "dev": true,
-          "optional": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "dev": true,
-          "optional": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2513,7 +2672,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -2532,6 +2694,9 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2545,25 +2710,44 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "global": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -2575,7 +2759,14 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2594,12 +2785,21 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -2613,25 +2813,38 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2657,7 +2870,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -2681,7 +2900,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -2693,19 +2916,33 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.2",
+        "statuses": "1.3.1"
+      }
     },
     "http-proxy": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -2747,7 +2984,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -2759,7 +3000,22 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "interpret": {
       "version": "1.0.4",
@@ -2771,7 +3027,10 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -2795,7 +3054,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.10.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -2807,7 +3069,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2819,7 +3084,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2837,13 +3105,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-function": {
       "version": "1.0.1",
@@ -2855,25 +3129,40 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-number-like": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.isfinite": "3.3.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2885,13 +3174,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2915,7 +3210,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2951,7 +3249,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2969,13 +3270,40 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
       "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.1.1",
+        "semver": "5.4.1"
+      }
     },
     "jimp": {
       "version": "0.2.28",
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "dev": true,
+      "requires": {
+        "bignumber.js": "2.4.0",
+        "bmp-js": "0.0.3",
+        "es6-promise": "3.3.1",
+        "exif-parser": "0.1.12",
+        "file-type": "3.9.0",
+        "jpeg-js": "0.2.0",
+        "load-bmfont": "1.3.0",
+        "mime": "1.4.1",
+        "mkdirp": "0.5.1",
+        "pixelmatch": "4.0.2",
+        "pngjs": "3.3.0",
+        "read-chunk": "1.0.1",
+        "request": "2.83.0",
+        "stream-to-buffer": "0.1.0",
+        "tinycolor2": "1.4.1",
+        "url-regex": "3.2.0"
+      },
       "dependencies": {
         "mime": {
           "version": "1.4.1",
@@ -3001,13 +3329,20 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
     },
     "js2xmlparser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xmlcreate": "1.0.2"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -3021,6 +3356,20 @@
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
       "dev": true,
+      "requires": {
+        "babylon": "7.0.0-beta.19",
+        "bluebird": "3.5.1",
+        "catharsis": "0.8.9",
+        "escape-string-regexp": "1.0.5",
+        "js2xmlparser": "3.0.0",
+        "klaw": "2.0.0",
+        "marked": "0.3.6",
+        "mkdirp": "0.5.1",
+        "requizzle": "0.2.1",
+        "strip-json-comments": "2.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "1.8.3"
+      },
       "dependencies": {
         "babylon": {
           "version": "7.0.0-beta.19",
@@ -3058,7 +3407,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3082,7 +3434,10 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3101,6 +3456,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3120,13 +3481,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "klaw": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -3138,7 +3505,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "lcov-parse": {
       "version": "0.0.10",
@@ -3150,7 +3520,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "limiter": {
       "version": "1.1.2",
@@ -3163,6 +3537,15 @@
       "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.3.0.tgz",
       "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
       "dev": true,
+      "requires": {
+        "buffer-equal": "0.0.1",
+        "mime": "1.4.1",
+        "parse-bmfont-ascii": "1.0.6",
+        "parse-bmfont-binary": "1.0.6",
+        "parse-bmfont-xml": "1.1.3",
+        "xhr": "2.4.0",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "mime": {
           "version": "1.4.1",
@@ -3176,25 +3559,47 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "loader-utils": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "localtunnel": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
       "integrity": "sha1-3MWSL9hWUQN9S94k/ZMkjQsk6wU=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "openurl": "1.1.1",
+        "request": "2.81.0",
+        "yargs": "3.29.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "qs": {
           "version": "6.4.0",
@@ -3206,13 +3611,45 @@
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
         },
         "yargs": {
           "version": "3.29.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
           "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
+          }
         }
       }
     },
@@ -3221,6 +3658,10 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
@@ -3294,13 +3735,20 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "marked": {
       "version": "0.3.6",
@@ -3312,13 +3760,32 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
     },
     "mime": {
       "version": "1.2.4",
@@ -3336,19 +3803,28 @@
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -3360,25 +3836,46 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
       "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
       "dependencies": {
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -3399,13 +3896,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-      "dev": true,
-      "optional": true
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -3430,6 +3920,13 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.1.tgz",
       "integrity": "sha512-f5DMJB0MqBaSuP2NAwPx7HyVKPdaozds0KsNe9XIP3npKWt/QUg73l5TTLRTSwfG/Y3AB0ktacuxX4QNcg6vVw==",
       "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.22",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
       "dependencies": {
         "lolex": {
           "version": "1.6.0",
@@ -3444,6 +3941,31 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
       "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
       "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.3.0",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
       "dependencies": {
         "process": {
           "version": "0.11.10",
@@ -3463,19 +3985,31 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -3488,11 +4022,45 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.2.1.tgz",
       "integrity": "sha1-rYUK/p261/SXByi0suR/7Rw4chw=",
       "dev": true,
+      "requires": {
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+        "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+        "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
+        "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+        "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+        "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+        "merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "spawn-wrap": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
+        "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+      },
       "dependencies": {
         "align-text": {
           "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+          }
         },
         "amdefine": {
           "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -3512,7 +4080,10 @@
         "append-transform": {
           "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+          }
         },
         "archy": {
           "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -3522,7 +4093,10 @@
         "arr-diff": {
           "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+          }
         },
         "arr-flatten": {
           "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
@@ -3547,37 +4121,83 @@
         "babel-code-frame": {
           "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+          }
         },
         "babel-generator": {
           "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
           "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+          }
         },
         "babel-messages": {
           "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
+          }
         },
         "babel-runtime": {
           "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+            "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+          }
         },
         "babel-template": {
           "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "babel-traverse": {
           "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+            "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "babel-types": {
           "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+          }
         },
         "babylon": {
           "version": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
@@ -3592,12 +4212,21 @@
         "brace-expansion": {
           "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+          }
         },
         "braces": {
           "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+          }
         },
         "builtin-modules": {
           "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -3607,7 +4236,12 @@
         "caching-transform": {
           "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
+          }
         },
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -3619,18 +4253,34 @@
           "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+          }
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          }
         },
         "cliui": {
           "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
@@ -3668,12 +4318,19 @@
         "cross-spawn": {
           "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+          }
         },
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+          }
         },
         "debug-log": {
           "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
@@ -3688,17 +4345,26 @@
         "default-require-extensions": {
           "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+          }
         },
         "detect-indent": {
           "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+          }
         },
         "error-ex": {
           "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+          }
         },
         "escape-string-regexp": {
           "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3714,28 +4380,51 @@
           "version": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
+          "requires": {
+            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "npm-run-path": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "strip-eof": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
+          },
           "dependencies": {
             "cross-spawn": {
               "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+              }
             }
           }
         },
         "expand-brackets": {
           "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+          }
         },
         "expand-range": {
           "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+          }
         },
         "extglob": {
           "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
         },
         "filename-regex": {
           "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -3745,17 +4434,32 @@
         "fill-range": {
           "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+          }
         },
         "find-cache-dir": {
           "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+          }
         },
         "find-up": {
           "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
+          }
         },
         "for-in": {
           "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3765,12 +4469,19 @@
         "for-own": {
           "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+          }
         },
         "foreground-child": {
           "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+          }
         },
         "fs.realpath": {
           "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3790,17 +4501,32 @@
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
         },
         "glob-base": {
           "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
         },
         "glob-parent": {
           "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
         },
         "globals": {
           "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -3816,18 +4542,30 @@
           "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
           "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
+          },
           "dependencies": {
             "source-map": {
               "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          }
         },
         "has-flag": {
           "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -3847,7 +4585,11 @@
         "inflight": {
           "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -3857,7 +4599,10 @@
         "invariant": {
           "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+          }
         },
         "invert-kv": {
           "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -3877,7 +4622,10 @@
         "is-builtin-module": {
           "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+          }
         },
         "is-dotfile": {
           "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3887,7 +4635,10 @@
         "is-equal-shallow": {
           "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+          }
         },
         "is-extendable": {
           "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3902,22 +4653,34 @@
         "is-finite": {
           "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+          }
         },
         "is-glob": {
           "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
         },
         "is-number": {
           "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
         },
         "is-posix-bracket": {
           "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -3952,7 +4715,10 @@
         "isobject": {
           "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
         },
         "istanbul-lib-coverage": {
           "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
@@ -3962,34 +4728,65 @@
         "istanbul-lib-hook": {
           "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
           "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
+          }
         },
         "istanbul-lib-instrument": {
           "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
           "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+          }
         },
         "istanbul-lib-report": {
           "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
           "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
           "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          },
           "dependencies": {
             "supports-color": {
               "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
           "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
           "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
+          }
         },
         "istanbul-reports": {
           "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
           "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
+          }
         },
         "js-tokens": {
           "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4004,7 +4801,10 @@
         "kind-of": {
           "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
         },
         "lazy-cache": {
           "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -4015,17 +4815,31 @@
         "lcid": {
           "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+          }
         },
         "load-json-file": {
           "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+          }
         },
         "locate-path": {
           "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
+          "requires": {
+            "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+          },
           "dependencies": {
             "path-exists": {
               "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4047,17 +4861,27 @@
         "loose-envify": {
           "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+          }
         },
         "lru-cache": {
           "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+          }
         },
         "md5-hex": {
           "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+          }
         },
         "md5-o-matic": {
           "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
@@ -4067,17 +4891,38 @@
         "mem": {
           "version": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+          }
         },
         "merge-source-map": {
           "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
           "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
+          }
         },
         "micromatch": {
           "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz"
+          }
         },
         "mimic-fn": {
           "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -4087,7 +4932,10 @@
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -4097,7 +4945,10 @@
         "mkdirp": {
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4107,17 +4958,29 @@
         "normalize-package-data": {
           "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
           "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+          }
         },
         "normalize-path": {
           "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
+          }
         },
         "npm-run-path": {
           "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-key": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
+          }
         },
         "number-is-nan": {
           "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -4132,17 +4995,28 @@
         "object.omit": {
           "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+          }
         },
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "optimist": {
           "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+          }
         },
         "os-homedir": {
           "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -4152,7 +5026,12 @@
         "os-locale": {
           "version": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "execa": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "mem": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
+          }
         },
         "p-finally": {
           "version": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -4167,22 +5046,37 @@
         "p-locate": {
           "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
+          }
         },
         "parse-glob": {
           "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
         },
         "parse-json": {
           "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+          }
         },
         "path-exists": {
           "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
         },
         "path-is-absolute": {
           "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4202,7 +5096,12 @@
         "path-type": {
           "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
         },
         "pify": {
           "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4217,17 +5116,27 @@
         "pinkie-promise": {
           "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+          }
         },
         "pkg-dir": {
           "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+          },
           "dependencies": {
             "find-up": {
               "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+              }
             }
           }
         },
@@ -4245,40 +5154,66 @@
           "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
           "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
           "dev": true,
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+          },
           "dependencies": {
             "is-number": {
               "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
+              "requires": {
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+              },
               "dependencies": {
                 "kind-of": {
                   "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                  }
                 }
               }
             },
             "kind-of": {
               "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
             }
           }
         },
         "read-pkg": {
           "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+          }
         },
         "read-pkg-up": {
           "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+          },
           "dependencies": {
             "find-up": {
               "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+              }
             }
           }
         },
@@ -4290,7 +5225,10 @@
         "regex-cache": {
           "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
           "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+          }
         },
         "remove-trailing-separator": {
           "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4310,7 +5248,10 @@
         "repeating": {
           "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+          }
         },
         "require-directory": {
           "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4331,12 +5272,18 @@
           "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+          }
         },
         "rimraf": {
           "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+          }
         },
         "semver": {
           "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -4351,7 +5298,10 @@
         "shebang-command": {
           "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+          }
         },
         "shebang-regex": {
           "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
@@ -4376,12 +5326,23 @@
         "spawn-wrap": {
           "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
           "integrity": "sha1-+ip5uZDLsLsAGNymdI2INnsZ7DE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+          }
         },
         "spdx-correct": {
           "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+          }
         },
         "spdx-expression-parse": {
           "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
@@ -4397,6 +5358,10 @@
           "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          },
           "dependencies": {
             "ansi-regex": {
               "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -4411,19 +5376,28 @@
             "strip-ansi": {
               "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+              }
             }
           }
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          }
         },
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         },
         "strip-eof": {
           "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -4438,7 +5412,14 @@
         "test-exclude": {
           "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
           "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+          }
         },
         "to-fast-properties": {
           "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -4455,12 +5436,23 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          },
           "dependencies": {
             "yargs": {
               "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+              }
             }
           }
         },
@@ -4473,12 +5465,19 @@
         "validate-npm-package-license": {
           "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+          }
         },
         "which": {
           "version": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
           "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+          }
         },
         "which-module": {
           "version": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -4500,11 +5499,20 @@
           "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+          },
           "dependencies": {
             "string-width": {
               "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              }
             }
           }
         },
@@ -4516,7 +5524,12 @@
         "write-file-atomic": {
           "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+          }
         },
         "y18n": {
           "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -4532,6 +5545,21 @@
           "version": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+          },
           "dependencies": {
             "camelcase": {
               "version": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -4542,33 +5570,61 @@
               "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
+              "requires": {
+                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                  }
                 }
               }
             },
             "load-json-file": {
               "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
               "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+              }
             },
             "path-type": {
               "version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
               "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+              }
             },
             "read-pkg": {
               "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
               "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                "path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
+              }
             },
             "read-pkg-up": {
               "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
               "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+              }
             },
             "strip-bom": {
               "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -4578,7 +5634,10 @@
             "yargs-parser": {
               "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
               "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+              }
             }
           }
         },
@@ -4586,6 +5645,9 @@
           "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          },
           "dependencies": {
             "camelcase": {
               "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -4630,25 +5692,40 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "object-keys": "1.0.11"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -4666,19 +5743,35 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      }
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -4710,7 +5803,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -4722,7 +5818,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "p-limit": {
       "version": "1.1.0",
@@ -4734,7 +5835,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
     },
     "pako": {
       "version": "0.2.9",
@@ -4758,43 +5862,69 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xml-parse-from-string": "1.0.1",
+        "xml2js": "0.4.19"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-headers": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-each": "0.3.2",
+        "trim": "0.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseurl": {
       "version": "1.3.2",
@@ -4812,7 +5942,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4837,6 +5970,9 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -4850,7 +5986,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -4886,25 +6027,37 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pixelmatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pngjs": "3.3.0"
+      }
     },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
     },
     "pkg-up": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -4922,7 +6075,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "is-number-like": "1.0.8"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -5001,18 +6158,28 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             }
           }
         },
@@ -5020,7 +6187,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         }
       }
     },
@@ -5040,37 +6210,69 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.4.0"
+      }
     },
     "regenerate": {
       "version": "1.3.3",
@@ -5088,19 +6290,32 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
+      }
     },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -5113,6 +6328,9 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -5144,19 +6362,52 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "ajv": {
           "version": "5.2.3",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
           "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "assert-plus": {
           "version": "1.0.0",
@@ -5174,19 +6425,28 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
         },
         "cryptiles": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
           "dependencies": {
             "boom": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
             }
           }
         },
@@ -5194,7 +6454,12 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
         },
         "har-schema": {
           "version": "2.0.0",
@@ -5206,13 +6471,23 @@
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ajv": "5.2.3",
+            "har-schema": "2.0.0"
+          }
         },
         "hawk": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.0.2"
+          }
         },
         "hoek": {
           "version": "4.2.0",
@@ -5224,7 +6499,12 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
         },
         "performance-now": {
           "version": "2.1.0",
@@ -5242,7 +6522,10 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
           "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
         }
       }
     },
@@ -5262,7 +6545,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -5275,6 +6562,9 @@
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
@@ -5288,7 +6578,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -5300,25 +6593,39 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "minimatch": "3.0.4"
+      }
     },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "ripemd160": {
       "version": "0.2.0",
@@ -5330,7 +6637,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx": {
       "version": "4.1.0",
@@ -5373,12 +6683,30 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
       "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.4",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.2",
+        "mime": "1.3.4",
+        "ms": "1.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
           "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
           "dev": true,
+          "requires": {
+            "ms": "0.7.3"
+          },
           "dependencies": {
             "ms": {
               "version": "0.7.3",
@@ -5398,7 +6726,13 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
           "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1"
+          }
         },
         "mime": {
           "version": "1.3.4",
@@ -5425,12 +6759,24 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "batch": "0.5.3",
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "http-errors": "1.5.1",
+        "mime-types": "2.1.17",
+        "parseurl": "1.3.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -5444,7 +6790,13 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
       "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.15.2"
+      }
     },
     "server-destroy": {
       "version": "1.0.1",
@@ -5486,7 +6838,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -5498,13 +6853,30 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.4",
+        "rechoir": "0.6.2"
+      }
     },
     "sinon": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
       "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.1.3",
+        "native-promise-only": "0.8.1",
+        "nise": "1.1.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.3.0",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.3"
+      }
     },
     "sinon-chai": {
       "version": "2.14.0",
@@ -5528,19 +6900,34 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "socket.io": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
       "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "1.8.0",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.6.0",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -5561,12 +6948,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -5581,6 +6975,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
       "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
       "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.0",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -5592,7 +6999,10 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -5607,12 +7017,21 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -5644,13 +7063,19 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -5675,6 +7100,16 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -5694,19 +7129,34 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
     },
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "stream-throttle": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.11.0",
+        "limiter": "1.1.2"
+      }
     },
     "stream-to": {
       "version": "0.2.2",
@@ -5718,19 +7168,30 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "stream-to": "0.2.2"
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -5742,13 +7203,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -5773,6 +7240,14 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -5790,13 +7265,20 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -5816,7 +7298,14 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
+      }
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -5834,7 +7323,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "object-path": "0.9.2"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -5846,7 +7339,10 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
     },
     "tinycolor2": {
       "version": "1.4.1",
@@ -5876,7 +7372,10 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim": {
       "version": "0.0.1",
@@ -5906,7 +7405,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -5919,7 +7421,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.3",
@@ -5945,13 +7450,23 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
         },
         "window-size": {
           "version": "0.1.0",
@@ -5972,7 +7487,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -5999,6 +7520,9 @@
       "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
       "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
@@ -6025,6 +7549,10 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -6038,7 +7566,10 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ip-regex": "1.0.3"
+      }
     },
     "user-home": {
       "version": "1.1.1",
@@ -6051,6 +7582,9 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -6082,19 +7616,31 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -6108,13 +7654,21 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "watchpack": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
+      "requires": {
+        "async": "0.9.2",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -6129,6 +7683,23 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
       "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0",
+        "async": "1.5.2",
+        "clone": "1.0.2",
+        "enhanced-resolve": "0.9.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.7.0",
+        "optimist": "0.6.1",
+        "supports-color": "3.2.3",
+        "tapable": "0.1.10",
+        "uglify-js": "2.7.5",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.9"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -6140,7 +7711,12 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -6158,13 +7734,22 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         },
         "uglify-js": {
           "version": "2.7.5",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "dev": true,
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -6190,7 +7775,13 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -6199,12 +7790,19 @@
       "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
+      "requires": {
+        "source-list-map": "0.1.8",
+        "source-map": "0.4.4"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -6212,13 +7810,21 @@
       "version": "2.0.0-pre-I0Z7U9OV",
       "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
       "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "express": "2.5.11",
+        "nopt": "3.0.6",
+        "underscore": "1.7.0"
+      }
     },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -6242,7 +7848,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -6254,13 +7864,20 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "ws": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
       "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
     },
     "wtf-8": {
       "version": "1.0.0",
@@ -6272,7 +7889,13 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
       "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "xml-parse-from-string": {
       "version": "1.0.1",
@@ -6284,7 +7907,11 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
     },
     "xmlbuilder": {
       "version": "9.0.4",
@@ -6327,6 +7954,22 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -6347,6 +7990,9 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "browser-sync": "^2.18.8",
     "coveralls": "^3.0.0",
     "cross-env": "^5.1.0",
-    "enigma.js": "^1.0.0",
+    "enigma.js": "^2.2.0",
     "eslint": "^3.8.0",
     "eslint-config-airbnb": "^12.0.0",
     "eslint-plugin-import": "^1.16.0",

--- a/src/enigma-mixin/halyard-enigma-mixin.js
+++ b/src/enigma-mixin/halyard-enigma-mixin.js
@@ -15,8 +15,12 @@ function createErrorMessage(errorType, qixError, item) {
 
 const halyardMixin = {
   types: 'Global',
-  init(properties) {
-    properties.api.Promise = properties.Promise;
+  init(args) {
+    if (args.config) {
+      args.api.Promise = args.config.Promise;
+    } else {
+      args.api.Promise = args.Promise;
+    }
   },
   extend: {
     createSessionAppUsingHalyard(halyard) {
@@ -74,7 +78,6 @@ const halyardMixin = {
       return that.Promise.all(deferredConnections).then(() =>
         app.getLocaleInfo().then((localeInfoResult) => {
           halyard.setDefaultSetStatements(convertQixGetLocalInfo(localeInfoResult), true);
-
           return app.globalApi.configureReload(true, true, false).then(
             () => app.setScript(halyard.getScript()).then(
               () => app.doReload().then(() => app.globalApi.getProgress(0).then(
@@ -106,16 +109,22 @@ const halyardMixin = {
   },
 };
 
+
 const exposeGlobalApi = {
   types: 'Doc',
-  init(properties) {
-    properties.api.globalApi = properties.api.session.getObjectApi({
+  init(args) {
+    const getObjectArgs = {
       handle: -1,
       id: 'Global',
       type: 'Global',
-      customType: 'Global',
-      delta: true,
-    });
+    };
+    if (args.config) {
+      getObjectArgs.customType = 'Global';
+      getObjectArgs.delta = true;
+    } else {
+      getObjectArgs.genericType = 'Global';
+    }
+    args.api.globalApi = args.api.session.getObjectApi(getObjectArgs);
   },
 };
 

--- a/test/integration/connection.spec.js
+++ b/test/integration/connection.spec.js
@@ -15,11 +15,11 @@ describe('Connections', () => {
     const table = new Halyard.Table(url, { name: 'Allsvenskan', headerRowNr: 1, characterSet: 'utf8' });
 
     halyard.addTable(table);
+    const docName = Utils.getUniqueDocName();
 
-    return Utils.getQixService().then((qix) => {
-      const docName = Utils.getUniqueDocName();
+    return Utils.openSession(docName).then((session) => {
 
-      return qix.global.createAppUsingHalyard(docName, halyard).then(result => qix.global.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Allsvenskan').then((result) => {
+      return session.createAppUsingHalyard(docName, halyard).then(result => session.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Allsvenskan').then((result) => {
         expect(result[0].qValue[0].qText).to.eql('Lag');
         expect(result[1].qValue[0].qText).to.eql('Hammarby');
 
@@ -37,10 +37,10 @@ describe('Connections', () => {
 
     halyard.addTable(table);
 
-    return Utils.getQixService().then((qix) => {
-      const docName = Utils.getUniqueDocName();
+    const docName = Utils.getUniqueDocName();
+    return Utils.openSession(docName).then((session) => {
 
-      return qix.global.createAppUsingHalyard(docName, halyard).then(result => qix.global.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Allsvenskan').then((result) => {
+      return session.createAppUsingHalyard(docName, halyard).then(result => session.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Allsvenskan').then((result) => {
         expect(result[0].qValue[0].qText).to.eql('Lag');
         expect(result[1].qValue[0].qText).to.eql('Hammarby');
 
@@ -48,7 +48,7 @@ describe('Connections', () => {
         expect(result[1].qValue[1].qText).to.eql('11 885');
       })))
       .catch((err) => {
-        throw new Error(err.qixError.parameter);
+        throw err;
       });
     });
   });
@@ -59,10 +59,10 @@ describe('Connections', () => {
 
     halyard.addTable(JSON.parse(data), 'Car Makers');
 
-    return Utils.getQixService().then((qix) => {
-      const docName = Utils.getUniqueDocName();
+    const docName = Utils.getUniqueDocName();
+    return Utils.openSession(docName).then((session) => {
 
-      return qix.global.createAppUsingHalyard(docName, halyard).then(result => qix.global.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
+      return session.createAppUsingHalyard(docName, halyard).then(result => session.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
         expect(result[0].qValue[0].qText).to.eql('make_id');
       })));
     });
@@ -75,10 +75,10 @@ describe('Connections', () => {
 
     halyard.addTable(table);
 
-    return Utils.getQixService().then((qix) => {
-      const docName = Utils.getUniqueDocName();
+    const docName = Utils.getUniqueDocName();
+    return Utils.openSession(docName).then((session) => {
 
-      return qix.global.createAppUsingHalyard(docName, halyard).then(result => qix.global.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
+      return session.createAppUsingHalyard(docName, halyard).then(result => session.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
         expect(result[0].qValue[0].qText).to.eql('make_id');
       })));
     });

--- a/test/integration/enigma-config.js
+++ b/test/integration/enigma-config.js
@@ -1,13 +1,13 @@
 import bluebird from 'bluebird';
 import WebSocket from 'ws';
-import qixSchema from 'enigma.js/schemas/qix/3.0/schema.json';
+import qixSchema from 'enigma.js/schemas/3.2.json';
 
 const config = {
   Promise: bluebird,
   schema: qixSchema,
   session: {
     port: '4848',
-    unsecure: true,
+    secure: false,
     disableCache: true,
   },
   createSocket(url) {

--- a/test/integration/enigma-mixin.spec.js
+++ b/test/integration/enigma-mixin.spec.js
@@ -11,21 +11,20 @@ halyard.addTable(carmakersPath, 'Car Makers');
 describe('Enigma Mixin', () => {
   it('should work to reload an existing app', () => {
     const docName = Utils.getUniqueDocName();
-    return Utils.getQixService().then(qix => qix.global.createAppUsingHalyard(docName, halyard).then(appResult => appResult.session.close().then(() => qix.global.reloadAppUsingHalyard(docName, halyard).then(() => qix.global.openApp(docName).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
+    return Utils.openSession(docName).then(session => session.createAppUsingHalyard(docName, halyard).then(appResult => appResult.session.close().then(() => Utils.openSession(docName)).then((session) => session.reloadAppUsingHalyard(docName, halyard).then(() => session.openDoc(docName).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
       expect(result[0].qValue[0].qText).to.eql('make_id');
     }))))));
   });
 
-  it('should work to create a session app with halyard', () => Utils.getQixService().then(qix => qix.global.createSessionAppUsingHalyard(halyard).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
+  it('should work to create a session app with halyard', () => Utils.openSession().then(session => session.createSessionAppUsingHalyard(halyard).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
     expect(result[0].qValue[0].qText).to.eql('make_id');
   }))));
 
   it('should work to reload an non-existing app with the createIfMissing param', () => {
     const docName = Utils.getUniqueDocName();
-
-    return Utils.getQixService().then(qix => qix.global.reloadAppUsingHalyard(docName, halyard, true).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
+    return Utils.openSession(docName).then(session => session.reloadAppUsingHalyard(docName, halyard, true).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
       expect(result[0].qValue[0].qText).to.eql('make_id');
-      return app.doSave().then(saveresult => app.session.close().then(() => qix.global.reloadAppUsingHalyard(docName, halyard, true).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
+      return app.doSave().then(saveresult => app.session.close().then(() => Utils.openSession(docName)).then((session) => session.reloadAppUsingHalyard(docName, halyard, true).then(app => app.getTableData(-1, 30, true, 'Car Makers').then((result) => {
         expect(result[0].qValue[0].qText).to.eql('make_id');
       }))));
     })));

--- a/test/integration/mixin-error-handling.spec.js
+++ b/test/integration/mixin-error-handling.spec.js
@@ -19,7 +19,7 @@ describe('Enigma Mixin error handling', () => {
 
     halyard.addTable(url, { name: 'Table' });
 
-    return Utils.getQixService().then(qix => qix.global.createAppUsingHalyard(docName, halyard).then((result) => {})
+    return Utils.openSession(docName).then(session => session.createAppUsingHalyard(docName, halyard).then((result) => {})
       .catch((err) => {
         expect(err.type).to.eql('Connection Error');
       }));
@@ -30,7 +30,7 @@ describe('Enigma Mixin error handling', () => {
 
     halyard.addTable(url, { name: 'Allsvenskan', fields: [{ src: 'apa', name: 'Test' }] });
 
-    return Utils.getQixService().then(qix => qix.global.createAppUsingHalyard(docName, halyard).then((result) => {})
+    return Utils.openSession(docName).then(session => session.createAppUsingHalyard(docName, halyard).then((result) => {})
       .catch((err) => {
         expect(err.type).to.eql('Loading Error');
       }));
@@ -41,7 +41,7 @@ describe('Enigma Mixin error handling', () => {
 
     halyard.addTable(url, { name: 'Allsvenskan', fields: [{ expr: 'adsfasdfdsf(aoa)', name: 'Test' }] });
 
-    return Utils.getQixService().then(qix => qix.global.createAppUsingHalyard(docName, halyard).then((result) => {})
+    return Utils.openSession(docName).then(session => session.createAppUsingHalyard(docName, halyard).then((result) => {})
       .catch((err) => {
         expect(err.type).to.eql('Syntax Error');
       }));

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -10,26 +10,21 @@ enigmaConfig.mixins = enigmaMixin;
 
 const docNamePrefix = 'HalyardIntegrationTest';
 
-
 export function getUniqueDocName() {
   return `${docNamePrefix}-${Math.floor(Math.random() * 100000)}`;
 }
 
-export function getQixService() {
-  return enigma.getService('qix', enigmaConfig);
+export function openSession(appId) {
+  enigmaConfig.url = `ws://localhost:4848/app/engineData-${appId}`;
+  return enigma.create(enigmaConfig).open();
 }
 
 export function removeAllTestDoc() {
-  return getQixService().then(qix => qix.global.getDocList().then((list) => {
-    const docsToDelete = [];
-
+  return openSession().then(qix => qix.getDocList().then(async (list) => {
     const integrationTestDocs = list.filter(doc => doc.qDocName.match(docNamePrefix));
-
-    integrationTestDocs.forEach((doc) => {
-      docsToDelete.push(qix.global.deleteApp(doc.qDocId));
-    });
-
-    return Promise.all(docsToDelete);
+    for (const doc of integrationTestDocs) {
+      await qix.deleteApp(doc.qDocId);
+    }
   }));
 }
 


### PR DESCRIPTION
@carlioth and I have:

Updated the mixins to support enigma.js version 2+

Also changed the tests to use enigma 2.2
(used the same, changed,  mixin code to run the tests using enigma 1 on the current master branch

Fixed the clean up of the tests to remove the apps one by one, since otherwise all apps are not removed.