### PR TITLE
Update api version to match component version

### DIFF
--- a/docs/api-spec.json
+++ b/docs/api-spec.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "halyard.js",
     "description": "Data import library for Qlik Analytics Platform",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "license": "MIT",
     "stability": "stable",
     "x-qlik-visibility": "public",


### PR DESCRIPTION
Package version was updated without generating a new spec which fails the cci build.